### PR TITLE
fix: correct pluralization typo for 'opportunities' in alert messages

### DIFF
--- a/scout_bounties.py
+++ b/scout_bounties.py
@@ -187,7 +187,7 @@ def main():
     # 1. Telegram / Discord Message Format (Markdown)
     notif_lines = [
         f"🎯 *New Bounty Alert* ({now_str})",
-        f"Found {len(new_bounties)} new opportunity{'ies' if len(new_bounties) > 1 else ''}:\n"
+        f"Found {len(new_bounties)} new opportunit{'ies' if len(new_bounties) > 1 else 'y'}:\n"
     ]
     for idx, b in enumerate(new_bounties, start=1):
         notif_lines.append(f"{idx}. *{b['title']}*")
@@ -211,7 +211,7 @@ def main():
 
     # Method C: GitHub Issue (Built-in, zero configuration)
     if github_token and repo_fullname:
-        issue_title = f"🎯 Bounty Alert: {len(new_bounties)} New Opportunity{'ies' if len(new_bounties) > 1 else ''} found"
+        issue_title = f"🎯 Bounty Alert: {len(new_bounties)} New Opportunit{'ies' if len(new_bounties) > 1 else 'y'} found"
         issue_body = (
             f"### Active Bounty Scan Results\n\n"
             f"**Scan Time:** {now_str}\n\n"


### PR DESCRIPTION
Fixes the typo where 'opportunity' + 'ies' resulted in 'opportunityies'.  The base string has been updated to 'opportunit' and the suffix logic updated to append 'y' for singular and 'ies' for plural.